### PR TITLE
Set tilesType to moc for ZTF

### DIFF
--- a/growth/too/tasks/tiles.py
+++ b/growth/too/tasks/tiles.py
@@ -107,10 +107,14 @@ def params_struct(dateobs, tobs=None, filt=['r'], exposuretimes=[60.0],
         params["catalog_n"] = 1.0
         params["powerlaw_dist_exp"] = 1.0
     elif schedule_strategy == "tiling":
-        if tele == "ZTF":
-            params["tilesType"] = "ranked"
-        else:
-            params["tilesType"] = "moc"
+        params["tilesType"] = "moc"
+        # FIXME: commented out because this requires precomputed tile indices,
+        # which are too large to store in git.
+        #
+        # if tele == "ZTF":
+        #     params["tilesType"] = "ranked"
+        # else:
+        #     params["tilesType"] = "moc"
     params["scheduleType"] = schedule_type
     params["timeallocationType"] = "powerlaw"
     params["nside"] = 256


### PR DESCRIPTION
I removed the `preComputed_ZTF_pixel_indices_256.dat` file from the repository because it is too large to effictively track with git and because we should be evaulating the HEALPix field footprints from the same vector representations that we use for the D3 visualization.

@mcoughlin suggests that setting `params["tilesType"] = "moc"` should work as a temporary workaround.