### PR TITLE
Speed up unit tests by calling create_db only once

### DIFF
--- a/growth/too/tests/conftest.py
+++ b/growth/too/tests/conftest.py
@@ -4,24 +4,24 @@ from .. import tasks
 from ..flask import app
 
 
-@pytest.fixture(autouse=True, scope='session')
-def temp_database(postgresql_proc):
+@pytest.fixture(scope='session')
+def _db(postgresql_proc):
     """Use a disposible Postgresql database for all tests."""
     database_uri = 'postgresql://postgres@{proc.host}:{proc.port}'.format(
         proc=postgresql_proc)
     app.config['SQLALCHEMY_DATABASE_URI'] = database_uri
     for key in app.config['SQLALCHEMY_BINDS']:
         app.config['SQLALCHEMY_BINDS'][key] = database_uri
+    from .. import models
+    models.create_all()
+    models.db.session.commit()
+    return models.db
 
 
 @pytest.fixture
-def database():
+def database(db_session):
     """Start from an empty database."""
-    from .. import models
-    models.create_all()
-    yield
-    models.db.session.commit()
-    models.db.drop_all()
+    pass
 
 
 @pytest.fixture

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
 packages = find:
 tests_require =
     pytest >= 3.0
+    pytest-flask-sqlalchemy
     pytest-postgresql
 
 [options.entry_points]
@@ -50,6 +51,9 @@ growth.too =
     templates/*.txt
     templates/*.email
     tests/data/*.xml
+
+[tool:pytest]
+mocked-sessions=growth.too.models.db.session
 
 # See the docstring in versioneer.py for instructions. Note that you must
 # re-run 'versioneer.py setup' after changing this section, and commit the


### PR DESCRIPTION
Call `growth.too.models.create_all()` once at pytest session scope, and then roll back to a clean database at the end of every test. This speeds up the unit tests significantly because it takes about 40 seconds to run `create_all()`, a cost that was being incurred once for each unit test.

The rollback is achieved with the help of the `pytest-flask-sqlalchemy` package.