### PR TITLE
Use consistent HEALPix ordering scheme for gwemopt

### DIFF
--- a/growth/too/models.py
+++ b/growth/too/models.py
@@ -219,8 +219,7 @@ def create_all():
 
                 for field_id, xyz in zip(fields['field_id'], quadrant_xyz):
                     for subfield_id, xyz in enumerate(xyz):
-                        ipix = hp.query_polygon(
-                            Localization.nside, xyz, nest=True)
+                        ipix = hp.query_polygon(Localization.nside, xyz)
                         db.session.merge(SubField(telescope=tele,
                                                   field_id=int(field_id),
                                                   subfield_id=int(subfield_id),
@@ -614,9 +613,10 @@ class Localization(db.Model):
     @property
     def flat_2d(self):
         """Get flat resolution HEALPix dataset, probability density only."""
-        return hp.ud_grade(
+        result = hp.ud_grade(
             rasterize(self.table_2d)['PROB'],
             self.nside, power=-2, order_in='NESTED', order_out='NESTED')
+        return hp.reorder(result, 'NESTED', 'RING')
 
     @property
     def flat(self):
@@ -624,9 +624,10 @@ class Localization(db.Model):
         distance."""
         if self.is_3d:
             data = rasterize(self.table)
-            return ud_grade(
+            result = ud_grade(
                 data['PROB'], data['DISTMU'], data['DISTSIGMA'],
                 self.nside, order_in='NESTED', order_out='NESTED')
+            return hp.reorder(result, 'NESTED', 'RING')
         else:
             return self.flat_2d,
 

--- a/growth/too/tasks/skymaps.py
+++ b/growth/too/tasks/skymaps.py
@@ -91,9 +91,8 @@ def contour(localization_name, dateobs):
 
     # Construct contours and return as a GeoJSON feature collection.
     levels = [50, 90]
-    paths = postprocess.contour(
-        cls, levels, degrees=True, nest=True, simplify=True)
-    center = postprocess.posterior_max(prob, nest=True)
+    paths = postprocess.contour(cls, levels, degrees=True, simplify=True)
+    center = postprocess.posterior_max(prob)
     localization.contour = {
         'type': 'FeatureCollection',
         'features': [

--- a/growth/too/tasks/tiles.py
+++ b/growth/too/tasks/tiles.py
@@ -19,7 +19,6 @@ import gwemopt.plotting
 import gwemopt.tiles
 import gwemopt.segments
 import gwemopt.catalog
-import healpy as hp
 from ligo import segments
 import numpy as np
 
@@ -396,10 +395,6 @@ def tile(localization_name, dateobs, telescope,
 
     params['map_struct'] = dict(
         zip(['prob', 'distmu', 'distsigma', 'distnorm'], localization.flat))
-
-    # gwemopt expects sky maps in RING ordering.
-    for key, value in params['map_struct'].items():
-        params['map_struct'][key] = hp.reorder(value, 'NESTED', 'RING')
 
     params['is3D'] = localization.is_3d
     params['localization_name'] = localization_name


### PR DESCRIPTION
gwemopt uses RING indexing. Use RING indexing wherever we use flat (non-multiresolution) HEALPix indices.