### PR TITLE
Clean up ZTF reference image task

### DIFF
--- a/growth/too/tasks/ref.py
+++ b/growth/too/tasks/ref.py
@@ -1,7 +1,8 @@
-import numpy as np
-from pyvo.dal import TAPService
 from celery.task import PeriodicTask
 from celery.utils.log import get_task_logger
+from celery.local import PromiseProxy
+import numpy as np
+import pyvo.dal
 
 from . import celery
 from .. import models
@@ -10,21 +11,18 @@ log = get_task_logger(__name__)
 
 __all__ = ('ztf_references',)
 
-
-def get_tap_client():
-    url = 'https://irsa.ipac.caltech.edu/TAP'
-    return TAPService(url)
+client = PromiseProxy(
+    pyvo.dal.TAPService,
+    ('https://irsa.ipac.caltech.edu/TAP',))
 
 
 @celery.task(base=PeriodicTask, shared=False, run_every=3600)
-def ztf_references(refstable=None):
-
-    if refstable is None:
-        refstable = get_tap_client().search("""
-        SELECT field, ccdid, qid, fid, maglimit FROM ztf.ztf_current_meta_ref
-        WHERE (nframes >= 15) AND (startobsdate >= '2018-02-05T00:00:00Z')
-        AND (field < 880)
-        """).to_table()
+def ztf_references():
+    refstable = client.search("""
+    SELECT field, ccdid, qid, fid, maglimit FROM ztf.ztf_current_meta_ref
+    WHERE (nframes >= 15) AND (startobsdate >= '2018-02-05T00:00:00Z')
+    AND (field < 880)
+    """).to_table()
 
     refs = refstable.group_by(['field', 'fid']).groups.aggregate(np.mean)
     refs = refs.filled()

--- a/growth/too/tests/test_ref.py
+++ b/growth/too/tests/test_ref.py
@@ -1,17 +1,30 @@
-import os
-from astropy.io import ascii
+from unittest.mock import Mock
+
+from astropy.table import Table
+import pkg_resources
+import pytest
 
 from .. import models
 from ..tasks import ref
 
 
-def test_refs():
+@pytest.fixture
+def mock_refstable():
+    filename = 'data/ztf_ref_table.dat'
+    with pkg_resources.resource_stream(__name__, filename) as f:
+        return Table.read(f, format='ascii')
 
-    payload = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                           'data/ztf_ref_table.dat')
 
-    refstable = ascii.read(payload)
-    ref.ztf_references(refstable=refstable)
+@pytest.fixture
+def mock_client(monkeypatch, mock_refstable):
+    client = Mock(**{
+        'search.return_value.to_table.return_value': mock_refstable})
+    monkeypatch.setattr('growth.too.tasks.ref.client', client)
+    return client
+
+
+def test_refs(mock_client):
+    ref.ztf_references()
     field = models.Field.query.filter_by(telescope='ZTF', field_id=324).one()
     assert field.reference_filter_ids == [1]
     assert field.reference_filter_mags == [21.326900]


### PR DESCRIPTION
* Replace the function for getting the TAP client with a proxy object that instantiates a singleton upon the first access.
* Clean up the unit test by using mocking and monkeypatching so as to avoid making changes to the function under test.