### PR TITLE
Disable network access during unit tests

### DIFF
--- a/growth/too/tests/conftest.py
+++ b/growth/too/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from pytest_socket import disable_socket
 
 from .. import tasks
 from ..flask import app
@@ -36,3 +37,7 @@ def celery(monkeypatch):
 def mail(monkeypatch):
     """Set the Flask-Mail MAIL_SUPPRESS_SEND flag."""
     monkeypatch.setattr(tasks.email.mail.state, 'suppress', True)
+
+
+def pytest_runtest_setup():
+    disable_socket()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 pytest >= 3.0
 pytest-postgresql
+pytest-socket


### PR DESCRIPTION
Out of abundance of caution, disable network access during unit tests so that we cannot accidentally trigger observations.