### PR TITLE
Send alert if desirability of tags changes

### DIFF
--- a/growth/too/gcn.py
+++ b/growth/too/gcn.py
@@ -210,8 +210,11 @@ def handle(payload, root):
                 )
             ).delay()
 
-        if not (DESIRABLE_TAGS & old_tags) and (DESIRABLE_TAGS & new_tags) \
-           and not (UNDESIRABLE_TAGS & new_tags):
+        old_alertable = bool((DESIRABLE_TAGS & old_tags) and not
+                             (UNDESIRABLE_TAGS & old_tags))
+        new_alertable = bool((DESIRABLE_TAGS & new_tags) and not
+                             (UNDESIRABLE_TAGS & new_tags))
+        if old_alertable != new_alertable:
             tasks.twilio.call_everyone.delay(
                 'event_new_voice', dateobs=dateobs)
             tasks.twilio.text_everyone.delay(


### PR DESCRIPTION
This way, we will get a phone call not only when an event of interest occurs, but also if an event of interest is retracted.