### PR TITLE
Fix IERS A download

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ jobs:
         postgresql: "11"
       install:
         - pip install pytest-cov coveralls -r requirements.txt -r test-requirements.txt
+        # FIXME: IERS download URL has changed.
+        # Remove this when https://github.com/astropy/astropy/pull/8993
+        # makes it into an Astropy release.
+        - pip install git+https://github.com/astropy/astropy@8ffa573a86d1783f110cdf9f3101a06a698e67bc
         - pip install -r requirements.txt
         - python -c 'from astropy.coordinates import EarthLocation; from astroplan import download_IERS_A; EarthLocation.get_site_names(); download_IERS_A()'
       script:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,7 +57,8 @@ RUN pip3 install --upgrade pip
 COPY requirements.txt /
 RUN pip3 install --no-cache-dir -r \
     /requirements.txt \
-    git+https://github.com/mher/flower@1a291b31423faa19450a272c6ef4ef6fe8daa286
+    git+https://github.com/mher/flower@1a291b31423faa19450a272c6ef4ef6fe8daa286 \
+    git+https://github.com/astropy/astropy@8ffa573a86d1783f110cdf9f3101a06a698e67bc  # https://github.com/astropy/astropy/pull/8993
 RUN rm /requirements.txt
 
 # Prime some cached Astropy data sources.


### PR DESCRIPTION
The USNO web site has changed from http to https. Astropy has been updated with the new URL but that change is not yet in a release.

See astropy/astropy#8993.

**Does this pull request make any changes to the database?**
No.