### PR TITLE
Set GROWTH datatabase connection timeout to 1 second

### DIFF
--- a/growth/too/flask.py
+++ b/growth/too/flask.py
@@ -10,7 +10,7 @@ from werkzeug.routing import BaseConverter
 app = Flask(__name__, instance_relative_config=True)
 app.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql:///growth-too-marshal'
 app.config['SQLALCHEMY_BINDS'] = {
-    'growthdb': 'postgresql:///growthtest'
+    'growthdb': 'postgresql:///growthtest?connect_timeout=1'
 }
 
 app.config['TEMPLATES_AUTO_RELOAD'] = True


### PR DESCRIPTION
We frequently do development on machines that do not have access to the GROWTH database. Opening pages that try to make queries to it can hang. Set the timeout to 1 second so that those queries fail quickly.

**Does this pull request make any changes to the database?**
No.