### PR TITLE
Run Flask app under Gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN cp *none-any.whl /wheelhouse
 FROM debian:testing-slim AS aptinstall
 
 RUN apt-get update && apt-get -y install --no-install-recommends \
+    gunicorn3 \
     openssh-client \
     python3-astropy \
     python3-astroquery \
@@ -31,6 +32,7 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
     python3-flask-login \
     python3-flask-sqlalchemy \
     python3-future \
+    python3-gevent \
     python3-healpy \
     python3-humanize \
     python3-h5py \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,7 +129,8 @@ services:
   flask:
     build: .
     image: growthastro/growth-too-marshal
-    command: run --with-threads --host=0.0.0.0 --port 8081
+    entrypoint: gunicorn3
+    command: --worker-class=gevent --workers=4 --threads=4 --bind=0.0.0.0:8081 --timeout 120 --graceful-timeout 120 growth.too.tool:app
     depends_on:
       - postgres
       - redis

--- a/docker/etc/nginx/conf.d/default.conf
+++ b/docker/etc/nginx/conf.d/default.conf
@@ -17,8 +17,7 @@ server {
     location / {
         client_max_body_size 16M;
         proxy_pass http://flask:8081;
-        proxy_set_header Host $host:$proxy_port;
-        proxy_redirect off;
+        proxy_set_header Host $proxy_host;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";


### PR DESCRIPTION
Flask has an embedded HTTP server, but it is only meant to be used for development purposes.

Run Flask under Gunicorn so that there are several workers processes that can handle requests concurrently.

This should make the GROWTH ToO Marshal feel much more responsive.

**Does this pull request make any changes to the database?**
No.