### PR TITLE
Use freezegun to change current time for scheduler unit test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
     python3-h5py \
     python3-lxml \
     python3-flask-mail \
+    python3-freezegun \
     python3-matplotlib \
     python3-networkx \
     python3-numpy \

--- a/growth/too/tests/test_gcn.py
+++ b/growth/too/tests/test_gcn.py
@@ -1,3 +1,4 @@
+import datetime
 from unittest import mock
 
 from astropy import time
@@ -6,12 +7,21 @@ import gcn
 import lxml.etree
 import numpy as np
 import pkg_resources
+import pytest
 
 from .. import models
 from ..jinja import btoa
 from ..flask import app
 from ..gcn import handle, listen
 from . import mock_download_file
+
+
+@pytest.mark.freeze_time('2017-08-17')
+def test_freeze_time():
+    """Test that freezing time works."""
+    assert datetime.date.today() == datetime.date(2017, 8, 17)
+    assert datetime.datetime.now() == datetime.datetime(2017, 8, 17)
+    assert time.Time.now() == time.Time('2017-08-17')
 
 
 @mock.patch('growth.too.tasks.skymaps.contour.run')
@@ -36,6 +46,7 @@ def test_grb180116a_gnd_pos(mock_from_cone, mock_tile, mock_contour,
 @mock.patch('growth.too.tasks.skymaps.contour.run')
 @mock.patch('growth.too.tasks.twilio.call_everyone.run')
 @mock.patch('astropy.io.fits.file.download_file', mock_download_file)
+@pytest.mark.freeze_time('2019-08-21')
 def test_grb180116a_fin_pos(mock_call_everyone, mock_contour,
                             celery, flask, mail):
     # Read test GCN
@@ -92,7 +103,7 @@ def test_grb180116a_fin_pos(mock_call_everyone, mock_contour,
         assert np.all(np.array(exposure.exposure_time) > 0)
         assert np.all(np.array(exposure.weight) <= 1)
 
-    assert np.isclose(plan.area, 604.8028691170906)
+    assert np.isclose(plan.area, 651.6459456904389)
 
     # Try submitting some of the observing plans.
     flask.post(

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 mirakuru <= 1.1.0  # FIXME: https://github.com/ClearcodeHQ/pytest-postgresql/issues/232
 pytest >= 3.0
+pytest-freezegun
 pytest-postgresql <= 1.4.1  # FIXME: https://github.com/ClearcodeHQ/pytest-postgresql/issues/232
 pytest-socket


### PR DESCRIPTION
The test `test_grb180116a_fin_pos` is sensitive to the current time because it generates an obesrving plan that is sensitive to the date as reported by `datetime.datetime.now()`. Use pytest-freezegun to artificially set the current time for the duration of this test.

**Does this pull request make any changes to the database?**
No.