### PR TITLE
Revert "Work around broken IERS downloads by depending on dev version of Astropy"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,6 @@ jobs:
             - postgresql-server-dev-11
         postgresql: "11"
       install:
-        # Fixes for flaky IERS servers that are on master but not yet in an astropy release
-        - pip install git+https://github.com/astropy/astropy@90db3ade9f5d883fedbe2a2e42b77938d5cc318e
-        - pip install git+https://github.com/astropy/astroplan@fa5fde10aab7b1720a13669bb214783dea8c5abb
-        - pip install git+https://github.com/astropy/astroquery@c96d5f4f306eee44f59de96e77d6f34bc4d784bb
-        - pip install git+https://github.com/astropy/reproject@eea092eb476c8aef95c917e1250b7796923e47f1
-        - pip install git+https://github.com/astropy/pyvo@33f64f9d4a5ab05dac12339d69c6b7c4bcf660e2
         - pip install pytest-cov coveralls -r requirements.txt -r test-requirements.txt
         - pip install -e .
         - growth-too iers

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,6 @@ RUN /opt/python/cp37-cp37m/bin/pip wheel --no-deps --no-cache-dir \
     lscsoft-glue \
     ligo-segments \
     python-ligo-lw \
-    # Fixes for flaky IERS servers that are on master but not yet in an astropy release
-    git+https://github.com/astropy/astropy@90db3ade9f5d883fedbe2a2e42b77938d5cc318e \
-    git+https://github.com/astropy/astroplan@fa5fde10aab7b1720a13669bb214783dea8c5abb \
-    git+https://github.com/astropy/astroquery@c96d5f4f306eee44f59de96e77d6f34bc4d784bb \
-    git+https://github.com/astropy/reprojectmanylinux201076c8aef95c917e1250b7796923e47f1 \
-    git+https://github.com/astropy/pyvo@33f64f9d4a5ab05dac12339d69c6b7c4bcf660e2 \
     git+https://github.com/mher/flower@1a291b31423faa19450a272c6ef4ef6fe8daa286 && \
     # Audit all binary wheels
     ls *.whl | xargs -L 1 auditwheel repair && \
@@ -101,7 +95,6 @@ COPY --from=wheel-deps /wheelhouse /wheelhouse
 RUN pip3 install --no-cache-dir -f /wheelhouse \
     flower \
     -r /requirements.txt
-RUN pip3 install --no-cache-dir /wheelhouse/*.whl
 
 
 #


### PR DESCRIPTION
Astropy 4.0 is out and so the IERS download issues are fixed.

This reverts commit 9f5b4a9ca4c8643e25e4df36ee1455e8fa702916.

**Does this pull request make any changes to the database?**
No.